### PR TITLE
Don't load Firetext on startup

### DIFF
--- a/laskyawm.js
+++ b/laskyawm.js
@@ -523,12 +523,6 @@ $(document).on('mouseleave', '.window', function() {
 	updateZIndex();
 });
 
-openWindow('/Apps/firetext/', {}, function(win, tab, div) {
-	if(deviceType !== 'mobile') $(div).addClass('maximized maximized-max');
-	clipResizableHandles.call(div, null, {position: $(div).position()});
-});
-
-
 function forceMinimize() {
 	var windows = childDivs.filter(function(win) {
 		return !win.classList.contains('minimized') || win.classList.contains('force-minimized');


### PR DESCRIPTION
I don’t believe we should auto load Firetext.

Maybe an idea for consideration, though, is remembering the windows opened during the previous session.
